### PR TITLE
Add Gradle migration and application settings

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'application'
 }
 
 group = 'org.example'
@@ -12,6 +13,14 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+application {
+    mainClass = 'org.example.Main'  // Define the main class
+}
+
+run {
+    standardInput = System.in
 }
 
 test {


### PR DESCRIPTION
- Introduced `GradleMigrationSettings` with `migrationVersion="1"` to support project migration.
- Added `application` plugin and defined `mainClass` as `org.example.Main` for the application entry point.
- Configured `run` task to handle standard input.
- Retained existing JUnit 5 dependencies and test configurations.
- Kept `GradleSettings` intact with linked external project settings.